### PR TITLE
Bind tmpnb and proxy to explicit interfaces.

### DIFF
--- a/roles/notebook/tasks/main.yml
+++ b/roles/notebook/tasks/main.yml
@@ -51,7 +51,10 @@
     name: configproxy
     env:
       CONFIGPROXY_AUTH_TOKEN: "{{ configproxy_auth_token }}"
-    command: --default-target http://127.0.0.1:9999 --ip="{{ notebook_host }}"
+    command: >
+      --default-target http://127.0.0.1:9999
+      --ip="{{ notebook_host }}"
+      --api-ip="127.0.0.1"
 
 - name: tmpnb
   docker:

--- a/roles/notebook/tasks/main.yml
+++ b/roles/notebook/tasks/main.yml
@@ -51,7 +51,7 @@
     name: configproxy
     env:
       CONFIGPROXY_AUTH_TOKEN: "{{ configproxy_auth_token }}"
-    command: --default-target http://127.0.0.1:9999
+    command: --default-target http://127.0.0.1:9999 --ip="{{ notebook_host }}"
 
 - name: tmpnb
   docker:
@@ -76,3 +76,4 @@
       --max_dock_workers={{ tmpnb_max_dock_workers }}
       --mem-limit={{ tmpnb_mem_limit }}
       --cpu-shares={{ tmpnb_cpu_shares }}
+      --ip="127.0.0.1"

--- a/script/launch.py
+++ b/script/launch.py
@@ -80,7 +80,7 @@ def launch_node(prefix="demo", region="iad", node_num=1, domain="tmpnb.org"):
     }
 
     inventory = '''[notebook]
-{user_server_name} ansible_ssh_user=root ansible_ssh_host={notebook_server_public} configproxy_auth_token={token}
+{user_server_name} ansible_ssh_user=root ansible_ssh_host={notebook_server_public} configproxy_auth_token={token} notebook_host={notebook_server_private}
 
 [proxy]
 {proxy_server_name} ansible_ssh_user=root ansible_ssh_host={proxy_server_public} notebook_host={notebook_server_private}


### PR DESCRIPTION
These were binding to all interfaces before when we only needed them on explicit interfaces:

* tmpnb's orchestrate belongs *only* on localhost for the proxy to be able to reach
* proxy should only be serviceable via the interface nginx reaches it from. In this case its service net but we should allow localhost too.