### PR TITLE
Lower limits and increase pool

### DIFF
--- a/vars.yml
+++ b/vars.yml
@@ -3,7 +3,7 @@
 
 # Configuration parameters for containers.
 
-tmpnb_pool_size: 8
+tmpnb_pool_size: 32
 tmpnb_cull_timeout: 120
 tmpnb_cull_period: 600
 tmpnb_image: jupyter/demo
@@ -12,7 +12,7 @@ tmpnb_redirect_uri: /tree
 tmpnb_command: ipython3 notebook --NotebookApp.base_url={base_path}
 tmpnb_max_dock_workers: 8
 tmpnb_docker_version: 1.13
-tmpnb_cpu_shares: 128
+tmpnb_cpu_shares: 32
 tmpnb_mem_limit: 4096m
 
 # GitHub users to grab public keys from


### PR DESCRIPTION
Since user groups seem to be using it more frequently, bump up default limits.

![](https://pbs.twimg.com/media/B8U71z1CIAExGwq.png)