### PR TITLE
SSL settings to get an A rating

### DIFF
--- a/roles/proxy/templates/nginx.conf.j2
+++ b/roles/proxy/templates/nginx.conf.j2
@@ -27,10 +27,17 @@ http {
         ssl on;
         ssl_certificate {{ ssl_cert_path }};
         ssl_certificate_key {{ ssl_key_path }};
-        ssl_session_timeout 5m;
-        ssl_protocols SSLv2 SSLv3 TLSv1;
-        ssl_ciphers HIGH:!aNULL:!MD5;
+        
+        ssl_ciphers "AES128+EECDH:AES128+EDH";
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
         ssl_prefer_server_ciphers on;
+        ssl_session_cache shared:SSL:10m;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+        add_header X-Content-Type-Options nosniff;
+        ssl_stapling on; # Requires nginx >= 1.3.7
+        ssl_stapling_verify on; # Requires nginx => 1.3.7
+        resolver_timeout 5s;        
+
 
         # Expose logs to "docker logs".
         # See https://github.com/nginxinc/docker-nginx/blob/master/Dockerfile#L12-L14


### PR DESCRIPTION
This was previously vulnerable to POODLE, as shown by https://www.ssllabs.com/ssltest/analyze.html

The new settings come roughly from https://cipherli.st/, minus the X-Frame-Options header they include since we use CSP, X-Frame options are deprecated, and we have several use cases for iframe embedding.

/cc @minrk @smashwilson