### PR TITLE
Allow other origins

### DIFF
--- a/roles/notebook/tasks/main.yml
+++ b/roles/notebook/tasks/main.yml
@@ -82,3 +82,4 @@
       --mem-limit={{ tmpnb_mem_limit }}
       --cpu-shares={{ tmpnb_cpu_shares }}
       --ip="127.0.0.1"
+      --allow-origin='*'

--- a/vars.yml
+++ b/vars.yml
@@ -8,7 +8,7 @@ tmpnb_cull_period: 400
 tmpnb_image: jupyter/demo
 tmpnb_static_files: /opt/conda/lib/python3.4/site-packages/IPython/html/static/
 tmpnb_redirect_uri: /tree
-tmpnb_command: ipython notebook --NotebookApp.base_url={base_path}
+tmpnb_command: ipython notebook --NotebookApp.base_url={base_path} --NotebookApp.allow_origin='*'
 tmpnb_max_dock_workers: 8
 tmpnb_docker_version: 1.18
 


### PR DESCRIPTION
Motivated by @danielballan and @Carreau requesting that they can use our tmpnb setup for live documentation (through the use of Thebe), this opens the flood gates of any site to use our tmpnb deployment to allow for live interactive documentation. It's the same setup being used on https://lambdaops.com/share-cell/, if you want a demo. I'd be tempted to make a separate domain for this kind of use (broken off from try.juptyer.org).

What do others think?