### PR TITLE
Update to the new jupyter/demo image

### DIFF
--- a/roles/common/tasks/docker.yml
+++ b/roles/common/tasks/docker.yml
@@ -22,7 +22,7 @@
   sudo: yes
 
 - name: install docker
-  apt: update_cache=yes name=lxc-docker-1.6.2
+  apt: update_cache=yes name=lxc-docker-1.7.1
   sudo: yes
 
 - name: python

--- a/roles/notebook/tasks/main.yml
+++ b/roles/notebook/tasks/main.yml
@@ -75,7 +75,6 @@
       --cull_period={{ tmpnb_cull_period }}
       --image={{ tmpnb_image }}
       --docker_version={{ tmpnb_docker_version }}
-      --static_files={{ tmpnb_static_files }}
       --redirect_uri={{ tmpnb_redirect_uri }}
       --command='{{ tmpnb_command }}'
       --max_dock_workers={{ tmpnb_max_dock_workers }}

--- a/roles/proxy/tasks/main.yml
+++ b/roles/proxy/tasks/main.yml
@@ -3,16 +3,6 @@
   command: docker pull {{ tmpnb_image }}
   sudo: yes
 
-# Get static resources from the userland container
-- name: static files container
-  docker:
-    image: "{{ tmpnb_image }}"
-    state: running
-    name: static-files
-    command: echo "#data-container-hack"
-    volumes:
-    - "{{ tmpnb_static_files }}"
-
 - name: configuration directories
   file: state=directory dest={{ item }} mode=0755
   with_items:
@@ -54,5 +44,3 @@
     name: nginx
     volumes: "{{ nginx_volumes }}"
     ports: "{{ nginx_ports }}"
-    volumes_from:
-    - static-files

--- a/roles/proxy/templates/nginx.conf.j2
+++ b/roles/proxy/templates/nginx.conf.j2
@@ -45,7 +45,7 @@ http {
         error_log /var/log/nginx/error.log;
 
         location ~ /(user[-/][a-zA-Z0-9]*)/static/(.*) {
-            alias {{ tmpnb_static_files }}$2;
+            proxy_pass https://cdn.jupyter.org/notebook/try-4.0.4/$2;
         }
 
         location / {

--- a/vars.yml
+++ b/vars.yml
@@ -10,7 +10,7 @@ tmpnb_static_files: /opt/conda/lib/python3.4/site-packages/IPython/html/static/
 tmpnb_redirect_uri: /tree
 tmpnb_command: start-notebook.sh --NotebookApp.base_url={base_path} --NotebookApp.allow_origin='*' --port={port}
 tmpnb_max_dock_workers: 8
-tmpnb_docker_version: 1.18
+tmpnb_docker_version: "auto"
 
 tmpnb_pool_size: 512
 tmpnb_cpu_shares: 32 # Overprovision, should be 2

--- a/vars.yml
+++ b/vars.yml
@@ -5,16 +5,15 @@
 
 tmpnb_cull_timeout: 120
 tmpnb_cull_period: 400
-tmpnb_image: jupyter/demo
-tmpnb_static_files: /opt/conda/lib/python3.4/site-packages/IPython/html/static/
+tmpnb_image: jupyter/demo:latest
 tmpnb_redirect_uri: /tree
 tmpnb_command: start-notebook.sh "--NotebookApp.base_url={base_path} --NotebookApp.allow_origin='*' --port={port}"
 tmpnb_max_dock_workers: 8
 tmpnb_docker_version: "auto"
 
-tmpnb_pool_size: 512
-tmpnb_cpu_shares: 32 # Overprovision, should be 2
-tmpnb_mem_limit: "512m"
+tmpnb_pool_size: 64
+tmpnb_cpu_shares: 32 # should be 16
+tmpnb_mem_limit: "2g"
 
 # GitHub users to grab public keys from
 

--- a/vars.yml
+++ b/vars.yml
@@ -8,7 +8,7 @@ tmpnb_cull_period: 400
 tmpnb_image: jupyter/demo
 tmpnb_static_files: /opt/conda/lib/python3.4/site-packages/IPython/html/static/
 tmpnb_redirect_uri: /tree
-tmpnb_command: start-notebook.sh --NotebookApp.base_url={base_path} --NotebookApp.allow_origin='*' --port={port}
+tmpnb_command: start-notebook.sh "--NotebookApp.base_url={base_path} --NotebookApp.allow_origin='*' --port={port}"
 tmpnb_max_dock_workers: 8
 tmpnb_docker_version: "auto"
 

--- a/vars.yml
+++ b/vars.yml
@@ -8,7 +8,7 @@ tmpnb_cull_period: 400
 tmpnb_image: jupyter/demo
 tmpnb_static_files: /opt/conda/lib/python3.4/site-packages/IPython/html/static/
 tmpnb_redirect_uri: /tree
-tmpnb_command: ipython notebook --NotebookApp.base_url={base_path} --NotebookApp.allow_origin='*'
+tmpnb_command: start-notebook.sh --NotebookApp.base_url={base_path} --NotebookApp.allow_origin='*' --port={port}
 tmpnb_max_dock_workers: 8
 tmpnb_docker_version: 1.18
 


### PR DESCRIPTION
This moves us over to the new version of the `jupyter/demo` image. I also upgraded our docker version to `1.7.1`. Sadly `1.8.2` was not available in this apt repository, so that's as far as I could go.