### PR TITLE
Add CPU quota

### DIFF
--- a/roles/notebook/tasks/main.yml
+++ b/roles/notebook/tasks/main.yml
@@ -82,5 +82,6 @@
       --max_dock_workers={{ tmpnb_max_dock_workers }}
       --mem-limit={{ tmpnb_mem_limit }}
       --cpu-shares={{ tmpnb_cpu_shares }}
+      --cpu-quota={{ tmpnb_cpu_quota }}
       --ip="127.0.0.1"
       --allow-origin='*'

--- a/vars.yml
+++ b/vars.yml
@@ -13,6 +13,7 @@ tmpnb_docker_version: "auto"
 
 tmpnb_pool_size: 64
 tmpnb_cpu_shares: 32 # should be 16
+tmpnb_cpu_quota: 200000 # 100 000 = 1 CPU per container
 tmpnb_mem_limit: "2g"
 
 # GitHub users to grab public keys from


### PR DESCRIPTION
Limit containers to 2 CPUs each

We can't deploy with this until Docker Hub build finishes after merging jupyter/tmpnb#240

cc @rgbkrk