### PR TITLE
add nodes to redirector in scripts

### DIFF
--- a/inventory.redirector
+++ b/inventory.redirector
@@ -1,0 +1,2 @@
+[redirector]
+tmpnb.org ansible_ssh_user=root ansible_ssh_host=tmpnb.org

--- a/script/add-redirect
+++ b/script/add-redirect
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+ROOT=$(dirname $0)/..
+
+n=$1
+
+if [ -z "$n" ]; then
+    echo 'specify node number'
+   exit -1
+fi
+
+HOST=https://tmp$n.tmpnb.org
+
+exec ansible -i "$ROOT/inventory.redirector" redirector -m shell -a "bash tmpnb-redirector/add_hosts.sh $HOST"

--- a/script/drop-redirect
+++ b/script/drop-redirect
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+ROOT=$(dirname $0)/..
+
+n=$1
+
+if [ -z "$n" ]; then
+    echo 'specify node number'
+   exit -1
+fi
+
+HOST=https://tmp$n.tmpnb.org
+
+exec ansible -i "$ROOT/inventory.redirector" redirector -m shell -a "bash tmpnb-redirector/drop_hosts.sh $HOST"

--- a/script/launch.py
+++ b/script/launch.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 '''
 This script requires 4 environment variables to be declared:

--- a/script/new-instance
+++ b/script/new-instance
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Bring up a complete node from scratch
+# 1. create node with launch.py
+# 2. add node to redirector with add-redirect
+# 3. deploy node with deploy
+
+set -e
+
+SCRIPT="$(dirname $0)"
+ROOT="$(dirname $0)/.."
+
+n=$1
+
+if [ -z "$n" ]; then
+   echo 'specify $n'
+   exit -1
+fi
+
+"$SCRIPT/launch.py" $n
+"$SCRIPT/add-redirect" $n
+
+export INVENTORY="$ROOT/inventory.$n"
+
+# disable initial host-key check for new hosts
+export ANSIBLE_HOST_KEY_CHECKING=False
+"$SCRIPT/deploy"

--- a/script/new-instance
+++ b/script/new-instance
@@ -23,4 +23,11 @@ export INVENTORY="$ROOT/inventory.$n"
 
 # disable initial host-key check for new hosts
 export ANSIBLE_HOST_KEY_CHECKING=False
+
+# wait for nodes to respond to ssh:
+while true; do
+    ansible -i "$INVENTORY" all -m ping && break || sleep 5
+done
+
+# deploy
 "$SCRIPT/deploy"


### PR DESCRIPTION
A new entrypoint

   ./script/new-instance NODE_NUM

does the whole shebang:

- create node
- add to redirector
- deploy application

add/drop-redirect standalone scripts are included for updating the tmpnb.org redirects